### PR TITLE
Join scopes with space instead of +

### DIFF
--- a/office365_client.js
+++ b/office365_client.js
@@ -17,7 +17,7 @@ Office365.requestCredential = function(options, credentialRequestCompleteCallbac
   const credentialToken = Random.secret();
 
   const scope = (options && options.requestPermissions) || ['offline_access', 'user.read'];
-  const flatScope = _.map(scope, encodeURIComponent).join('+');
+  const flatScope = encodeURIComponent(scope.join(' '));
 
   const loginStyle = OAuth._loginStyle('office365', config, options);
 


### PR DESCRIPTION
According to the official docs scope is a list of space separated scopes: https://docs.microsoft.com/en-us/azure/active-directory/develop/v2-oauth2-auth-code-flow

> A space-separated list of scopes that you want the user to consent to. For the /authorize leg of the request, this can cover multiple resources, allowing your app to get consent for multiple web APIs you want to call.

This fixes this and removes underscore dependency.